### PR TITLE
Move the base url out into a constant

### DIFF
--- a/lib/sunlight/congress.rb
+++ b/lib/sunlight/congress.rb
@@ -5,7 +5,7 @@ require "sunlight/congress/committee"
 
 module Sunlight
   module Congress
-    BASE_URL = "http://congress.api.sunlightfoundation.com"
+    BASE_URI = "http://congress.api.sunlightfoundation.com"
 
     def self.api_key
       @api_key

--- a/lib/sunlight/congress/committee.rb
+++ b/lib/sunlight/congress/committee.rb
@@ -13,7 +13,7 @@ class Sunlight::Congress::Committee
   end
 
   def self.by_committee_id(committee_id)
-    uri = URI("#{Sunlight::Congress::BASE_URL}/committees?committee_id=#{committee_id}&apikey=#{Sunlight::Congress.api_key}")
+    uri = URI("#{Sunlight::Congress::BASE_URI}/committees?committee_id=#{committee_id}&apikey=#{Sunlight::Congress.api_key}")
 
     JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
   end

--- a/lib/sunlight/congress/district.rb
+++ b/lib/sunlight/congress/district.rb
@@ -12,13 +12,13 @@ module Sunlight
       end
 
       def self.by_zipcode(zipcode)
-        uri = URI("#{Sunlight::Congress::BASE_URL}/districts/locate?zip=#{zipcode}&apikey=#{Sunlight::Congress.api_key}")
+        uri = URI("#{Sunlight::Congress::BASE_URI}/districts/locate?zip=#{zipcode}&apikey=#{Sunlight::Congress.api_key}")
 
         new(JSON.load(Net::HTTP.get(uri))["results"].first)
       end
 
       def self.by_latlong(latitude, longitude)
-        uri = URI("#{Sunlight::Congress::BASE_URL}/districts/locate?latitude=#{latitude}&longitude=#{longitude}&apikey=#{Sunlight::Congress.api_key}")
+        uri = URI("#{Sunlight::Congress::BASE_URI}/districts/locate?latitude=#{latitude}&longitude=#{longitude}&apikey=#{Sunlight::Congress.api_key}")
 
         new(JSON.load(Net::HTTP.get(uri))["results"].first)
       end

--- a/lib/sunlight/congress/legislator.rb
+++ b/lib/sunlight/congress/legislator.rb
@@ -16,13 +16,13 @@ class Sunlight::Congress::Legislator
   end
 
   def self.by_zipcode(zipcode)
-    uri = URI("#{Sunlight::Congress::BASE_URL}/legislators/locate?zip=#{zipcode}&apikey=#{Sunlight::Congress.api_key}")
+    uri = URI("#{Sunlight::Congress::BASE_URI}/legislators/locate?zip=#{zipcode}&apikey=#{Sunlight::Congress.api_key}")
 
     JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
   end
 
   def self.by_latlong(latitude, longitude)
-    uri = URI("#{Sunlight::Congress::BASE_URL}/legislators/locate?latitude=#{latitude}&longitude=#{longitude}&apikey=#{Sunlight::Congress.api_key}")
+    uri = URI("#{Sunlight::Congress::BASE_URI}/legislators/locate?latitude=#{latitude}&longitude=#{longitude}&apikey=#{Sunlight::Congress.api_key}")
 
     JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
   end


### PR DESCRIPTION
This commit moves the base url (http://congress.api.sunlightfoundation.com) into a
constant to make it easier to fix should it change in the future.
