### PR TITLE
Support for Legislator.by_name & by_state

### DIFF
--- a/lib/sunlight/congress/legislator.rb
+++ b/lib/sunlight/congress/legislator.rb
@@ -1,12 +1,10 @@
 require 'sunlight/congress'
 
 class Sunlight::Congress::Legislator
-  attr_accessor :first_name, :last_name, :website
+  attr_accessor :bioguide_id, :birthday, :chamber, :contact_form, :crp_id, :district, :facebook_id, :fax, :fec_ids, :first_name, :gender, :govtrack_id, :in_office, :last_name, :lis_id, :middle_name, :name_suffix, :nickname, :office, :party, :phone, :senate_class, :state, :state_name, :state_rank, :thomas_id, :title, :twitter_id, :votesmart_id, :website, :youtube_id
 
   def initialize(options)
-    self.first_name = options["first_name"]
-    self.last_name = options["last_name"]
-    self.website = options["website"]
+    options.each { |k,v| eval("@#{k}=#{v.inspect}") }
   end
 
   def self.by_zipcode(zipcode)
@@ -18,6 +16,23 @@ class Sunlight::Congress::Legislator
   def self.by_latlong(latitude, longitude)
     uri = URI("#{Sunlight::Congress::BASE_URI}/legislators/locate?latitude=#{latitude}&longitude=#{longitude}&apikey=#{Sunlight::Congress.api_key}")
 
+    JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
+  end
+
+  def self.by_name(name)
+    uri = URI("#{Sunlight::Congress::BASE_URI}/legislators?query=#{name}&apikey=#{Sunlight::Congress.api_key}")
+    JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
+
+  end
+
+  def self.by_state(state)
+    if state.size == 2
+      state_search, state_param = "state", state.upcase
+    else
+      state_search, state_param = "state_name", state.capitalize
+    end
+
+    uri = URI("#{Sunlight::Congress::BASE_URI}/legislators?#{state_search}=#{state_param}&apikey=#{Sunlight::Congress.api_key}")
     JSON.load(Net::HTTP.get(uri))["results"].collect{|json| new(json) }
   end
 end

--- a/test/integration/legislators_test.rb
+++ b/test/integration/legislators_test.rb
@@ -23,4 +23,35 @@ class TestIntegrationCongress < MiniTest::Unit::TestCase
 
     assert_equal "Joe", legislators.first.first_name
   end
+
+  def test_legislators_by_name
+    stub_request(:get, "http://congress.api.sunlightfoundation.com/legislators?query=joe&apikey=thisismykey")
+      .to_return(body: '{"results":[{"first_name":"Joe"}]}')
+
+    legislators = Sunlight::Congress::Legislator.by_name("joe")
+
+    assert_equal "Joe", legislators.first.first_name
+  end
+
+  def test_legislators_by_state
+    stub_request(:get, "http://congress.api.sunlightfoundation.com/legislators?state=CA&apikey=thisismykey")
+      .to_return(body: '{"results": [{"first_name":"Joe",
+                                       "state":"CA",
+                                       "state_name":"California"}]}')
+
+    legislators = Sunlight::Congress::Legislator.by_state("CA")
+
+    assert_equal "CA", legislators.first.state
+    assert_equal "California", legislators.first.state_name
+
+    stub_request(:get, "http://congress.api.sunlightfoundation.com/legislators?state_name=California&apikey=thisismykey")
+      .to_return(body: '{"results": [{"first_name":"Joe",
+                                       "state":"CA",
+                                       "state_name":"California"}]}')
+
+    legislators = Sunlight::Congress::Legislator.by_state("California")
+
+    assert_equal "CA", legislators.first.state
+    assert_equal "California", legislators.first.state_name
+  end
 end


### PR DESCRIPTION
One of my first PR's, and first open source one, so excuse me for any knucklehead mistakes!

This PR adds support for:
- searching legislators by their name fields
- searching legislators by state
- accompanying teats

To search by name:

``` ruby
Sunlight::Congress::Legislator.by_name("Pelosi")
```

To search by state, enter either the state abbreviation or the full name. Capitalization doesn't matter:

``` ruby
Sunlight::Congress::Legislator.by_state("CA")
Sunlight::Congress::Legislator.by_state("ca")
Sunlight::Congress::Legislator.by_state("california")
```

While I was at it I also added accessors all Legislator attributes. Ok if that's in this too? Hope so.
