### PR TITLE
Use the encrypted endpoint

### DIFF
--- a/lib/sunlight/congress.rb
+++ b/lib/sunlight/congress.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 
 module Sunlight
   module Congress
-    BASE_URI = "http://congress.api.sunlightfoundation.com"
+    BASE_URI = "https://congress.api.sunlightfoundation.com"
 
     def self.api_key
       @api_key


### PR DESCRIPTION
This updates the Congress API's base URI to use `https://`. We recommend this for all Congress API queries, especially those using location. For more rationale on why, I wrote a recent blog post for Sunlight on it:

https://sunlightfoundation.com/blog/2014/01/28/encrypting-our-congress-api-and-protecting-your-location/

I admit though, I haven't actually tested this commit - I'm assuming net/http will handle the `https://` protocol transparently. If you'd like me to do more testing before merging, I can do that.
